### PR TITLE
Set deployed image and tag from parameters

### DIFF
--- a/deploy/deploy.yml
+++ b/deploy/deploy.yml
@@ -577,3 +577,4 @@ parameters:
     value: quay.io/cloudservices/kessel-spicedb-operator
   - name: IMAGE_TAG
     required: true
+    value: latest

--- a/deploy/deploy.yml
+++ b/deploy/deploy.yml
@@ -527,7 +527,7 @@ objects:
           - --crd=false
           - --config
           - /opt/operator/config.yaml
-          image: quay.io/cloudservices/kessel-spicedb-operator:22b4a49
+          image: ${IMAGE}:${IMAGE_TAG}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -572,3 +572,8 @@ objects:
           seccompProfile:
             type: RuntimeDefault
         serviceAccountName: spicedb-operator
+parameters:
+  - name: IMAGE
+    value: quay.io/cloudservices/kessel-spicedb-operator
+  - name: IMAGE_TAG
+    required: true


### PR DESCRIPTION
After this PR is merged, `IMAGE_TAG` will automatically be set based on the `ref` value defined for each env in app-interface. `IMAGE` will also be used to test the image released from Konflux (different Quay repo).