### PR TITLE
adds required RPM scan task for konflux

### DIFF
--- a/.tekton/spicedb-operator-pull-request.yaml
+++ b/.tekton/spicedb-operator-pull-request.yaml
@@ -254,6 +254,23 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
+    - name: rpms-signature-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:7aa4d3c95e2b963e82fdda392f7cb3d61e3dab035416cf4a3a34e43cf3c9c9b8
+        - name: kind
+          value: task
+        resolver: bundles
     - name: build-image-index
       params:
       - name: IMAGE

--- a/.tekton/spicedb-operator-push.yaml
+++ b/.tekton/spicedb-operator-push.yaml
@@ -251,6 +251,23 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
+    - name: rpms-signature-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:7aa4d3c95e2b963e82fdda392f7cb3d61e3dab035416cf4a3a34e43cf3c9c9b8
+        - name: kind
+          value: task
+        resolver: bundles
     - name: build-image-index
       params:
       - name: IMAGE


### PR DESCRIPTION
adds required rpm-scans task for konflux, without it konflux fails showing a required test is missing

https://groups.google.com/a/redhat.com/g/konflux-announce/c/CSoUFI9d1k8/m/0l4wPs_JBAAJ