### PR TITLE
Adding SC-Branch Build Support

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -3,6 +3,7 @@ set -exv
 IMAGE="quay.io/cloudservices/kessel-spicedb-operator"
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 GIT_COMMIT=$(git rev-parse --short HEAD)
+SECURITY_COMPLIANCE_TAG="sc-$(date +%Y%m%d)-$(git rev-parse --short=7 HEAD)"
 
 if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
     echo "QUAY_USER and QUAY_TOKEN must be set"
@@ -14,9 +15,27 @@ if [[ -z "$RH_REGISTRY_USER" || -z "$RH_REGISTRY_TOKEN" ]]; then
     exit 1
 fi
 
-DOCKER_CONF="$PWD/.docker"
+# Create tmp dir to store data in during job run (do NOT store in $WORKSPACE)
+export TMP_JOB_DIR=$(mktemp -d -p "$HOME" -t "jenkins-${JOB_NAME}-${BUILD_NUMBER}-XXXXXX")
+echo "job tmp dir location: $TMP_JOB_DIR"
+
+function job_cleanup() {
+    echo "cleaning up job tmp dir: $TMP_JOB_DIR"
+    rm -fr $TMP_JOB_DIR
+}
+
+trap job_cleanup EXIT ERR SIGINT SIGTERM
+
+DOCKER_CONF="$TMP_JOB_DIR/.docker"
+
 mkdir -p "$DOCKER_CONF"
 docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
 docker --config="$DOCKER_CONF" build --build-arg GIT_COMMIT=$GIT_COMMIT --no-cache -t "${IMAGE}:${IMAGE_TAG}" . -f ./Dockerfile.openshift
-docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
+
+if [[ "$GIT_BRANCH" == "origin/security-compliance" ]]; then
+    docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:${SECURITY_COMPLIANCE_TAG}"
+    docker --config="$DOCKER_CONF" push "${IMAGE}:${SECURITY_COMPLIANCE_TAG}"
+else
+    docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
+fi


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Added support for building a container image based on the Security-Compliance (SC) Branch.
- Setup all container image builds to be constructed within a `/tmp` directory.
   - This is to ensure secrets are not accidentally baked into the built image.

## Ticket reference (if applicable)

- https://issues.redhat.com/browse/OSD-27577