### PR TITLE
Add FIPS configuration to Dockerfile.openshift

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,21 +1,29 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1154 AS builder
 ARG TARGETARCH
 USER root
-RUN microdnf install -y tar gzip make which
-# install platform specific go version
-RUN curl -O -J  https://dl.google.com/go/go1.22.0.linux-${TARGETARCH}.tar.gz
-RUN tar -C /usr/local -xzf go1.22.0.linux-${TARGETARCH}.tar.gz
-RUN ln -s /usr/local/go/bin/go /usr/local/bin/go
+RUN microdnf install -y tar gzip make which go-toolset
 
 WORKDIR /go/src/app
-ENV CGO_ENABLED=0
+ENV CGO_ENABLED=1
 
 COPY go.mod go.sum ./
+RUN go mod download
+
 COPY . .
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod go build ./cmd/...
+# adds fips-detect tool for FIPS validation -- likely not needed long term
+RUN mkdir /tmp/go && GOPATH=/tmp/go GOCACHE=/tmp/go go install github.com/acardace/fips-detect@latest
+
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod \
+    go mod tidy && \
+    GOEXPERIMENT=strictfipsruntime,boringcrypto GOOS=linux GOARCH=${TARGETARCH} go build -tags=fips_enabled -o /usr/local/bin/spicedb-operator ./cmd/...
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1154
 
+# installs RHEL fork of go to be able to validate with go tools for FIPS -- likely not needed long term
+RUN microdnf install -y go-toolset
+
+COPY --from=builder /usr/local/bin/spicedb-operator /usr/local/bin/spicedb-operator
+COPY --from=builder /tmp/go/bin/fips-detect /usr/local/bin/
 COPY --from=builder /go/src/app/validated-update-graph.yaml /opt/operator/config.yaml
-COPY --from=builder /go/src/app/spicedb-operator /usr/local/bin/spicedb-operator
+
 ENTRYPOINT ["spicedb-operator"]


### PR DESCRIPTION
Counterpart PR to https://github.com/project-kessel/inventory-api/pull/293 and https://github.com/project-kessel/relations-api/pull/334

Taken from @tonytheleg's original comment

> * adds the go-toolset package to both the builder container and the final container versus installing Go from upstream
> the version of Go from go-toolset contains modifications made for RHEL which replaces BoringSSL with OpenSSL. OpenSSL is approved and validated for FedRAMP and FIPS, BoringSSL is not
> * making go tool available on the final image will also aid in proving FIPS compliance for audits
> * installs fips-detect to simplify proving FIPS validation during audits as well (More on [fips-detect](https://github.com/acardace/fips-detect)

Verification performed in CRC
```
❯ oc rsh -c spicedb-operator spicedb-operator-9c857f8cc-bc5jf 
sh-4.4$ fips-detect /usr/local/bin/spicedb-operator
FIPS System Report
Host running in FIPS mode ...No <- CRC not running in FIPS mode, expected
FIPS-capable crypto library ...Yes!
FIPS-capable Go binary ...Yes!
```
