### PR TITLE
Bump base image to ubi9

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1154 AS builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1736404155 AS builder
 ARG TARGETARCH
 USER root
 RUN microdnf install -y tar gzip make which go-toolset
@@ -17,7 +17,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/g
     go mod tidy && \
     GOEXPERIMENT=strictfipsruntime,boringcrypto GOOS=linux GOARCH=${TARGETARCH} go build -tags=fips_enabled -o /usr/local/bin/spicedb-operator ./cmd/...
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1154
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1736404155
 
 # installs RHEL fork of go to be able to validate with go tools for FIPS -- likely not needed long term
 RUN microdnf install -y go-toolset


### PR DESCRIPTION
- Bumps base image to ubi9

Validated in CRC
<img width="726" alt="Screenshot 2025-01-30 at 2 15 07 PM" src="https://github.com/user-attachments/assets/18e05427-a69d-4c06-b329-8e0584d90fc6" />

Manifest https://quay.io/repository/tcreller/spicedb-operator/manifest/sha256:db8419b283150a44acab714cac640ce15e5a49b12f4e75488a56062f86cd7c03