### PR TITLE
Update tekton pipelines to use new Service Account

### DIFF
--- a/.tekton/spicedb-operator-pull-request.yaml
+++ b/.tekton/spicedb-operator-pull-request.yaml
@@ -531,7 +531,8 @@ spec:
       optional: true
     - name: netrc
       optional: true
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-spicedb-operator
   workspaces:
   - name: workspace
     volumeClaimTemplate:

--- a/.tekton/spicedb-operator-push.yaml
+++ b/.tekton/spicedb-operator-push.yaml
@@ -528,7 +528,8 @@ spec:
       optional: true
     - name: netrc
       optional: true
-  taskRunTemplate: {}
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-spicedb-operator
   workspaces:
   - name: workspace
     volumeClaimTemplate:


### PR DESCRIPTION
- Update konflux pipelines to use new service account as required before June 14th when old service account pipelines is deactivated.
- Will close https://github.com/project-kessel/spicedb-operator/pull/97