### PR TITLE
RHCLOUD-45844: adds renovate.json to configure Konflux mintmaker PR updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabledManagers": [
+    "github-actions",
+    "tekton",
+    "dockerfile"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["dockerfile"],
+      "schedule": ["* 0-1 * * 0"]
+    }
+  ]
+}

--- a/README-redhat.md
+++ b/README-redhat.md
@@ -53,6 +53,7 @@ The below table captures changes that diverge from the upstream bundle release. 
 
 |Change|Reason|
 |------|------|
+|Added the `renovate.json` file|This configures Mintmaker (part of Konflux) to prevent Go pkg update PRs and move to weekly updates for Dockerfile base image updates|
 |Removed the `update-graph` ConfigMap|The `update-graph` is useful for defining the SpiceDB version to use for a cluster, and controlling automatic upgrades. Since we build and use our own SpiceDB image, this feature is disabled in our `SpiceDbClusters` CR, so the ConfigMap is not needed|
 |`spec.containers.image` has been updated to use the Red Hat built SpiceDB|This ensures the SpiceDB image running in clusters complies with Red Hat policies, and security standards|
 |CPU and Memory adjustments|The CPU and Memory requests/limits have been increased for our deployment needs|


### PR DESCRIPTION
## Describe your changes
Adds a `renovate.json` file to customize  Konflux updates by overriding default settings
* updates the `dockerfile` manager to only update once a week on sunday at between midnight and 2am (default was every 4 hours)
* disables all managers except `dockerfile`, `tekton`, and `github-actions` to disable go pkg updates, along with other unused managers (See [example default config](https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json#L28C3-L92C5) for full list of managers normally enabled)
* updates README-redhat for the change

This will hopefully disable PR's for Go pkg updates, leaving only Tekton and Dockefile base image updates.

Related Docs:
* [Configure using Renovate](https://konflux-ci.dev/docs/mintmaker/user/#configuration)
* [Renovate File location options](https://docs.renovatebot.com/configuration-options/)

## Ticket reference (if applicable)
Fixes RHCLOUD-45844

