### PR TITLE
RHCLOUD-44400: Updates to improve the fork syncing process

### DIFF
--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -46,7 +46,13 @@ The current go-toolset version constraint is documented in `README-redhat.md`.
 4. Resolve any merge conflicts using the **Merge Action** column in the drift
    tracking table in `README-redhat.md`
 5. For `go.mod` and `go.sum` conflicts, reset to upstream entirely:
-   `git checkout sync-upstream-<tag> -- <all go.mod and go.sum files with conflicts>`
+   ```bash
+   # Find all conflicting go.mod/go.sum/go.work files
+   git diff --name-only --diff-filter=U --relative | grep -E "mod|sum|work"
+
+   # Reset them to the upstream version
+   git checkout sync-upstream-<tag> -- <file1> <file2> ...
+   ```
 6. For any file not listed in the table, accept the upstream (incoming) version
 
 ### Step 3: Update SYNC.md

--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -33,7 +33,7 @@ fork is already up to date and stop.
 **Important**: Before proceeding, check the `go` directive in the upstream
 `go.mod` at the target tag:
 ```bash
-git show tags/<tag>:go.mod | head -5
+git show tags/<tag>:go.mod | grep -E '^go '
 ```
 If the Go version exceeds our go-toolset version, stop and report the issue.
 The current go-toolset version constraint is documented in `README-redhat.md`.

--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: sync-upstream
+description: Sync the SpiceDB Operator fork from the latest upstream release. Auto-detects the latest tag, merges, resolves conflicts, runs post-merge cleanup, and builds/installs the validate-upgrade-path tool.
+disable-model-invocation: true
+argument-hint: [--tag <tag>]
+---
+
+# Sync SpiceDB Operator from Upstream
+
+Syncs this fork from the latest upstream release of
+[authzed/spicedb-operator](https://github.com/authzed/spicedb-operator).
+
+## Arguments
+
+- `--tag <tag>` — (optional) override the upstream tag to sync to. If omitted,
+  the skill auto-detects the latest release tag from upstream.
+
+## Process
+
+### Step 1: Determine the Target Tag
+
+If `--tag` was provided, use that. Otherwise, find the latest release tag from
+the upstream repository:
+
+```bash
+git fetch upstream --tags
+git tag -l 'v*' --sort=-v:refname | head -1
+```
+
+Compare this to the current tag in `SYNC.md`. If they match, report that the
+fork is already up to date and stop.
+
+**Important**: Before proceeding, check the `go` directive in the upstream
+`go.mod` at the target tag:
+```bash
+git show tags/<tag>:go.mod | head -5
+```
+If the Go version exceeds our go-toolset version, stop and report the issue.
+The current go-toolset version constraint is documented in `README-redhat.md`.
+
+### Step 2: Sync
+
+1. `git checkout -b sync-upstream-<tag> tags/<tag>`
+2. `git checkout -b merge-upstream-<tag> main`
+3. `git merge sync-upstream-<tag>`
+4. Resolve any merge conflicts using the **Merge Action** column in the drift
+   tracking table in `README-redhat.md`
+5. For `go.mod` and `go.sum` conflicts, reset to upstream entirely:
+   `git checkout sync-upstream-<tag> -- <all go.mod and go.sum files with conflicts>`
+6. For any file not listed in the table, accept the upstream (incoming) version
+
+### Step 3: Update SYNC.md
+
+Update `SYNC.md` with the new tag and the commit SHA of the upstream tag:
+```bash
+git rev-parse tags/<tag>
+```
+Commit the update.
+
+### Step 4: Post-Merge Cleanup
+
+1. Run `./scripts/redhat-diff.sh --stat`
+2. Remove any **stale files** listed in the warning:
+   ```bash
+   git rm <file1> <file2> ...
+   ```
+3. Reset any **diverged files** listed in the warning:
+   ```bash
+   git checkout tags/<tag> -- <file1> <file2> ...
+   ```
+4. Commit the cleanup
+5. Re-run `./scripts/redhat-diff.sh --stat` to confirm clean output
+
+### Step 5: Build and Install validate-upgrade-path
+
+Build and install the tool so it is available system-wide:
+```bash
+make install-validate-upgrade-path
+```
+Verify it is in PATH:
+```bash
+which validate-upgrade-path
+```
+
+### Step 6: Push and Create PR
+
+1. Push the branch:
+   ```bash
+   git push origin merge-upstream-<tag>
+   ```
+2. Create a PR to main (**do not squash commits**)
+3. Post the Red Hat diff on the PR:
+   ```bash
+   ./scripts/redhat-diff.sh --pr <pr-number>
+   ```
+
+### Step 7: Summary
+
+Report:
+- Old tag → new tag
+- PR link
+- Number of Red Hat changes, stale files cleaned, diverged files reset
+- Whether validate-upgrade-path was successfully installed
+- Remind the user to review the PR and check CI before merging

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ release/
 e2e/cluster-state/**
 e2e/*.lck
 e2e/*.lck.*
+bin/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ e2e/cluster-state/**
 e2e/*.lck
 e2e/*.lck.*
 bin/
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# CLAUDE.md — SpiceDB Operator Fork (Red Hat)
+
+This is Red Hat's fork of [authzed/spicedb-operator](https://github.com/authzed/spicedb-operator).
+See `README-redhat.md` for a full list of Red Hat-specific changes and their rationale.
+
+## Upstream Sync Process
+
+This fork is periodically synced from upstream using a merge-based workflow.
+See `SYNC.md` for the currently synced upstream tag.
+
+### Merge Conflict Resolution Rules
+
+When merging upstream changes, resolve conflicts using the **Merge Action** column
+in the drift tracking table in `README-redhat.md`. The four actions are:
+
+- **Keep ours**: always preserve the Red Hat version of this file
+- **Re-apply**: accept upstream changes, then re-apply our specific modifications
+  (e.g., change runners to `ubuntu-latest`, add `if: false`, use `Dockerfile.openshift`)
+- **Delete**: file should not exist in our fork; remove if upstream re-adds it
+- **Red Hat only**: file exists only in our fork; no upstream equivalent — keep as-is
+
+**For all other files not listed in the table**: accept the upstream (incoming) version.
+This includes all Go source code, `go.mod`, `go.sum`, protobuf definitions, and any
+new files introduced by upstream.
+
+**For `go.mod` and `go.sum` conflicts**: do not resolve these line-by-line. Instead,
+reset all `go.mod` and `go.sum` files to the upstream version entirely:
+```
+git checkout sync-upstream-<tag> -- <all go.mod and go.sum files with conflicts>
+```
+This ensures Go dependencies stay aligned with upstream, since git auto-merges
+non-conflicting lines and may preserve newer dependency versions from our fork
+that we no longer maintain independently.
+
+### Workflow Runner Mappings
+
+When upstream introduces or modifies workflows we keep, replace their runner with ours:
+- `depot-*`, `buildjet-*`, or any custom runner → `ubuntu-latest`
+
+### Post-Merge Cleanup
+
+After the merge completes, run `./scripts/redhat-diff.sh --stat` to check for:
+- **Stale files**: upstream deleted/renamed files that survived the merge — remove them
+- **Diverged files**: upstream files where the merge produced different content — reset
+  them with `git checkout tags/<tag> -- <file>`
+- **Red Hat changes**: the actual changes to review
+
+### Deployment File (deploy/deploy.yml)
+
+This file is NOT synced from upstream via merge. It is manually maintained based on
+the upstream `bundle.yaml` from each release. See the deployment changes table in
+`README-redhat.md` for the specific modifications made for OpenShift compatibility.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,11 @@ new files introduced by upstream.
 **For `go.mod` and `go.sum` conflicts**: do not resolve these line-by-line. Instead,
 reset all `go.mod` and `go.sum` files to the upstream version entirely:
 ```
-git checkout sync-upstream-<tag> -- <all go.mod and go.sum files with conflicts>
+# Find all conflicting go.mod/go.sum/go.work files
+git diff --name-only --diff-filter=U --relative | grep -E "mod|sum|work"
+
+# Reset them to the upstream version
+git checkout sync-upstream-<tag> -- <file1> <file2> ...
 ```
 This ensures Go dependencies stay aligned with upstream, since git auto-merges
 non-conflicting lines and may preserve newer dependency versions from our fork

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ build-validate-upgrade-path: $(VALIDATE_UPGRADE_PATH) ## Build the validate-upgr
 $(VALIDATE_UPGRADE_PATH):
 	go build -C tools -o ../$(VALIDATE_UPGRADE_PATH) ./validate-upgrade-path/
 
+.PHONY: install-validate-upgrade-path
+install-validate-upgrade-path: ## Install validate-upgrade-path to $GOPATH/bin
+	go install -C tools ./validate-upgrade-path/
+
 .PHONY: clean
 clean: ## Remove built binaries
 	rm -rf $(BIN_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+BIN_DIR := bin
+VALIDATE_UPGRADE_PATH := $(BIN_DIR)/validate-upgrade-path
+
+.PHONY: build-validate-upgrade-path
+build-validate-upgrade-path: $(VALIDATE_UPGRADE_PATH) ## Build the validate-upgrade-path tool
+
+$(VALIDATE_UPGRADE_PATH):
+	go build -C tools -o ../$(VALIDATE_UPGRADE_PATH) ./validate-upgrade-path/
+
+.PHONY: clean
+clean: ## Remove built binaries
+	rm -rf $(BIN_DIR)
+
+.PHONY: help
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/README-redhat.md
+++ b/README-redhat.md
@@ -33,6 +33,7 @@ The table below captures all changes to our fork from upstream. Each entry inclu
 | `Makefile` | Added | Build tooling for Red Hat-specific tools (e.g., `validate-upgrade-path`) | Red Hat only |
 | `tools/validate-upgrade-path/` | Added | CLI tool to validate SpiceDB upgrade paths against the operator's update graph. Useful for verifying upgrades when managing SpiceDB images outside the operator's built-in update mechanism | Red Hat only |
 | `.gitignore` | Updated to ignore `bin/` directory | Prevents built binaries from being committed | Re-apply |
+| `CLAUDE.md` | Replaced with our own | Contains Red Hat-specific merge conflict resolution rules for upstream syncs | Keep ours |
 | `README-redhat.md` | Added | Documents all Red Hat fork changes and rationale | Red Hat only |
 | `SYNC.md` | Added | Tracks the current upstream version synced to this fork | Red Hat only |
 | `.yamllint` | Added | YAML linting configuration | Red Hat only |

--- a/README-redhat.md
+++ b/README-redhat.md
@@ -6,19 +6,36 @@ This document captures all changes made by Red Hat that diverge from the upstrea
 
 ### Drift Tracking
 
-The table below captures high level changes to our fork from upstream and the reason for these changes.
+The table below captures all changes to our fork from upstream. Each entry includes the affected files, what changed, why, and how to handle conflicts during upstream syncs.
 
-|Change|Reason|
-|------|------|
-|Dependabot intervals changed to daily |This better aligns with other Kessel Services|
-|All active workflows defined by Authzed updated use the `ubuntu-latest` image for the runner|Authzed uses a custom self-hosted runner in their workflows which we don't have access to|
-|Build Test - Build Container Image workflow uses `Dockerfile.openshift` vs `Dockerfile`|This ensures the image build test uses our custom Dockerfile vs upstreams|
-|Non-critical workflows disabled or removed|Workflows that do not impact code functionality or Red Hat builds are disabled.<br><br> This includes:<br> * E2E test<br> * Yaml & Markdown Linting<br> * CLA workflow<br> * Release workflows|
-|Added the security scanning workflow|Required ConsoleDot platform security workflow to check for CVE's in code and images|
-|Added push/pull tekton pipelines|Used for Konflux PR and merge builds|
-|Added Dockerfile.openshift|Dockerfile used by Konflux for building images, to comply with requirements of using UBI as the base image, and to ensure FIPS-compliant builds using Go Toolset|
-|`build_deploy.sh` script added|Legacy script used by App Interface for container image builds pre-Konflux. Still used for building images locally for testing operator updates|
-| `deploy/deploy.yml` added|This is the main deployment file for deploying SpiceDB Operator to OpenShift clusters. It contains all required CRD's, ClusterRoles/Bindings, and various Kubernetes objects required to run the operator that ship with a release from Authzed, but with key updates made to support running on OpenShift clusters (see below)|
+**Merge actions:**
+- **Keep ours**: always preserve the Red Hat version of this file
+- **Re-apply**: accept upstream changes, then re-apply our specific modifications
+- **Delete**: file should not exist in our fork; remove if upstream re-adds it
+- **Red Hat only**: file exists only in our fork; no upstream equivalent
+
+| File(s) | Change | Reason | Merge Action |
+|---------|--------|--------|-------------|
+| `.github/dependabot.yml` | Removed | Aligns with Red Hat mandates to leverage Konflux | Delete |
+| `.github/renovate.json` | Replaced with our own config | Configures Mintmaker (part of Konflux) to prevent Go pkg update PRs and move to weekly updates for Dockerfile base image updates | Keep ours |
+| Active workflows in `.github/workflows/` | Runner changed to `ubuntu-latest` | Authzed uses custom self-hosted runners (`depot-*`, `buildjet-*`) which we don't have access to | Re-apply |
+| `.github/workflows/build-test.yaml` | Build Container Image job uses `Dockerfile.openshift` instead of `Dockerfile`; disabled E2E tests (`if: false`) | Ensures image build test uses our custom Dockerfile; E2E tests not critical for our builds | Re-apply |
+| `.github/workflows/lint.yaml` | Disabled YAML & Markdown linting (`if: false`) | Not critical to Red Hat builds | Re-apply |
+| `.github/workflows/cla.yaml` | Removed | Not applicable to our fork | Delete |
+| `.github/workflows/release.yaml` | Removed | Not applicable to our fork | Delete |
+| `.github/workflows/security-scanning.yml` | Added | Required ConsoleDot platform security workflow for CVE scanning | Red Hat only |
+| `.tekton/spicedb-operator-pull-request.yaml`, `.tekton/spicedb-operator-push.yaml` | Added | Konflux PR and merge build pipelines | Red Hat only |
+| `Dockerfile.openshift` | Added | FIPS-compliant builds using UBI base image and Go Toolset for Konflux | Red Hat only |
+| `build_deploy.sh` | Added | Legacy App Interface build script, still used for local image builds when testing operator updates | Red Hat only |
+| `deploy/deploy.yml` | Added | Main deployment file for SpiceDB Operator on OpenShift clusters with CRDs, RBAC, and customizations for OpenShift (see deployment table below) | Red Hat only |
+| `config/operator_openshift.yaml` | Added | OpenShift-specific operator configuration | Red Hat only |
+| `scripts/redhat-diff.sh` | Added | Script to isolate Red Hat-specific changes from upstream sync PRs for easier code review | Red Hat only |
+| `Makefile` | Added | Build tooling for Red Hat-specific tools (e.g., `validate-upgrade-path`) | Red Hat only |
+| `tools/validate-upgrade-path/` | Added | CLI tool to validate SpiceDB upgrade paths against the operator's update graph. Useful for verifying upgrades when managing SpiceDB images outside the operator's built-in update mechanism | Red Hat only |
+| `.gitignore` | Updated to ignore `bin/` directory | Prevents built binaries from being committed | Re-apply |
+| `README-redhat.md` | Added | Documents all Red Hat fork changes and rationale | Red Hat only |
+| `SYNC.md` | Added | Tracks the current upstream version synced to this fork | Red Hat only |
+| `.yamllint` | Added | YAML linting configuration | Red Hat only |
 
 
 &nbsp;
@@ -49,16 +66,15 @@ For more info on Go Toolset and FIPS certifications at Red Hat:
 
 Each release of the SpiceDB Operator includes a `bundle.yaml` that contains all the necessary resources and CRD’s to deploy the operator. The deployment file under `deploy/deploy.yml` incorporates the contents of the `bundle.yaml` with customizations that remove unwanted configurations and allow us to deploy into OpenShift clusters.
 
-The below table captures changes that diverge from the upstream bundle release. Each release of SpiceDB Operator will require a review of the bundle to pull in any changes required, which may require updating the below table.
+The below table captures changes in `deploy/deploy.yml` that diverge from the upstream bundle release. Each release of SpiceDB Operator will require a review of the bundle to pull in any changes required, which may require updating the below table.
 
-|Change|Reason|
-|------|------|
-|Added the `renovate.json` file|This configures Mintmaker (part of Konflux) to prevent Go pkg update PRs and move to weekly updates for Dockerfile base image updates|
-|Removed the `update-graph` ConfigMap|The `update-graph` is useful for defining the SpiceDB version to use for a cluster, and controlling automatic upgrades. Since we build and use our own SpiceDB image, this feature is disabled in our `SpiceDbClusters` CR, so the ConfigMap is not needed|
-|`spec.containers.image` has been updated to use the Red Hat built SpiceDB|This ensures the SpiceDB image running in clusters complies with Red Hat policies, and security standards|
-|CPU and Memory adjustments|The CPU and Memory requests/limits have been increased for our deployment needs|
-|`runAsUser` and `runAsGroup` directives from both container and pod `securityContexts` have been removed|These violate OpenShift security policies and prevent the image from running due to using the `nobody` user|
-|The `config` volume/volume mount has been removed|This volume is used to facilitate the `update-graph` ConfigMap which was also removed|
+| Change | Reason |
+|--------|--------|
+| Removed the `update-graph` ConfigMap | The `update-graph` is useful for defining the SpiceDB version to use for a cluster, and controlling automatic upgrades. Since we build and use our own SpiceDB image, this feature is disabled in our `SpiceDbClusters` CR, so the ConfigMap is not needed |
+| `spec.containers.image` updated to use Red Hat built SpiceDB | Ensures the SpiceDB image running in clusters complies with Red Hat policies and security standards |
+| CPU and Memory adjustments | Requests/limits have been increased for our deployment needs |
+| `runAsUser` and `runAsGroup` removed from container and pod `securityContexts` | These violate OpenShift security policies and prevent the image from running due to using the `nobody` user |
+| The `config` volume/volume mount removed | This volume facilitates the `update-graph` ConfigMap which was also removed |
 
 
 &nbsp;
@@ -80,10 +96,12 @@ Update `SYNC.md` as part of any PR that merges changes from the upstream [authze
 
 If changes are made to our fork that diverge from upstream that are not captured in this README, make sure to update this file with any relevant changes. Be sure to capture the change and reason in the table above.
 
-An easy way to capture differences is to use `git diff` and compare your synced branch to the upstream tag branch to see all differences between upstream and the current state.
+An easy way to capture differences is to use `scripts/redhat-diff.sh` which compares the merge branch against the upstream tag and shows only Red Hat-specific changes:
 
 ```bash
-# assumes you have an `upstream` remote for the upstream source code
-git checkout -b upstream-<tag> tags/<tag>
-git diff upstream-<tag>..<your-synced-branch>
+# Show summary of Red Hat changes for this sync
+./scripts/redhat-diff.sh --stat
+
+# Show all cumulative Red Hat changes vs upstream
+./scripts/redhat-diff.sh --all --stat
 ```

--- a/scripts/redhat-diff.sh
+++ b/scripts/redhat-diff.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+#
+# redhat-diff.sh - Show only Red Hat-specific changes introduced or modified during
+#                  an upstream sync, filtering out pure upstream changes and unchanged
+#                  Red Hat modifications.
+#
+# How it works:
+#   For each file that has Red Hat modifications on the merge branch, the script
+#   compares the "Red Hat delta" (diff from upstream tag) before and after the sync.
+#   Only files where this delta changed are shown — meaning the Red Hat-specific
+#   modifications were added, updated, or removed during this sync.
+#
+# Usage:
+#   ./scripts/redhat-diff.sh                    # print diff to stdout
+#   ./scripts/redhat-diff.sh --stat             # print diffstat summary only
+#   ./scripts/redhat-diff.sh --pr <number>      # post diff as a comment on a GitHub PR
+#   ./scripts/redhat-diff.sh --tag <tag>        # override the new tag from SYNC.md
+#   ./scripts/redhat-diff.sh --branch <branch>  # compare against a branch other than HEAD
+#   ./scripts/redhat-diff.sh --base <branch>    # base branch to compare from (default: main)
+#   ./scripts/redhat-diff.sh --all              # show cumulative Red Hat delta from upstream
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo "Error: not inside a git repository" >&2
+    exit 1
+}
+SYNC_FILE="$REPO_ROOT/SYNC.md"
+
+# Defaults
+TAG=""
+BRANCH="HEAD"
+BASE="main"
+PR_NUMBER=""
+STAT_ONLY=false
+SHOW_ALL=false
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Show Red Hat-specific changes made during an upstream sync.
+
+By default, compares the Red Hat delta (diff from upstream) before and after
+the sync. Only files where the Red Hat modifications changed are shown.
+Use --all to show the full cumulative Red Hat delta from upstream.
+
+Options:
+  --tag <tag>        Override the upstream tag (default: read from SYNC.md on branch)
+  --branch <branch>  Branch to compare (default: HEAD)
+  --base <branch>    Base branch to compare from (default: main)
+  --stat             Show diffstat summary only
+  --all              Show all Red Hat changes vs upstream (cumulative)
+  --pr <number>      Post the diff as a comment on the given GitHub PR
+  -h, --help         Show this help message
+EOF
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tag)    TAG="$2"; shift 2 ;;
+        --branch) BRANCH="$2"; shift 2 ;;
+        --base)   BASE="$2"; shift 2 ;;
+        --stat)   STAT_ONLY=true; shift ;;
+        --all)    SHOW_ALL=true; shift ;;
+        --pr)
+            if ! command -v gh >/dev/null 2>&1; then
+                echo "Error: the --pr flag requires the GitHub CLI (gh) to be installed." >&2
+                echo "Install it from https://cli.github.com/" >&2
+                exit 1
+            fi
+            PR_NUMBER="$2"; shift 2 ;;
+        -h|--help) usage ;;
+        *) echo "Unknown option: $1" >&2; usage ;;
+    esac
+done
+
+# Read new tag from SYNC.md on the branch being compared
+read_tag_from_ref() {
+    local ref="$1"
+    git -C "$REPO_ROOT" show "$ref:SYNC.md" 2>/dev/null \
+        | sed -n 's/^TAG:[[:space:]]*//p' \
+        | tr -d '[:space:]'
+}
+
+if [[ -z "$TAG" ]]; then
+    TAG=$(read_tag_from_ref "$BRANCH")
+    if [[ -z "$TAG" ]]; then
+        echo "Error: could not parse TAG from SYNC.md on $BRANCH" >&2
+        exit 1
+    fi
+fi
+
+# Verify the new tag exists locally
+if ! git -C "$REPO_ROOT" rev-parse "tags/$TAG" >/dev/null 2>&1; then
+    echo "Error: tag '$TAG' not found. Run 'git fetch upstream --tags' first." >&2
+    exit 1
+fi
+
+# --all mode: show cumulative Red Hat delta
+if [[ "$SHOW_ALL" == true ]]; then
+    echo "Comparing $BRANCH against upstream tag: $TAG (all Red Hat changes)" >&2
+    if [[ "$STAT_ONLY" == true ]]; then
+        git -C "$REPO_ROOT" diff --stat "tags/$TAG..$BRANCH"
+    else
+        git -C "$REPO_ROOT" diff "tags/$TAG..$BRANCH"
+    fi
+    exit 0
+fi
+
+# Read old tag from SYNC.md on the base branch
+OLD_TAG=$(read_tag_from_ref "$BASE")
+if [[ -z "$OLD_TAG" ]]; then
+    echo "Error: could not parse TAG from SYNC.md on $BASE" >&2
+    exit 1
+fi
+
+if ! git -C "$REPO_ROOT" rev-parse "tags/$OLD_TAG" >/dev/null 2>&1; then
+    echo "Error: old tag '$OLD_TAG' not found. Run 'git fetch upstream --tags' first." >&2
+    exit 1
+fi
+
+echo "Comparing Red Hat delta: $BASE ($OLD_TAG) -> $BRANCH ($TAG)" >&2
+
+# Get all files that have Red Hat modifications on either side
+ALL_RH_FILES=$(
+    {
+        git -C "$REPO_ROOT" diff --name-only "tags/$TAG..$BRANCH"
+        git -C "$REPO_ROOT" diff --name-only "tags/$OLD_TAG..$BASE"
+    } | sort -u
+)
+
+if [[ -z "$ALL_RH_FILES" ]]; then
+    echo "No Red Hat-specific changes found." >&2
+    exit 0
+fi
+
+# Extract only the added/removed lines from a diff, stripping headers,
+# hunk markers, and context lines so that comparisons are not thrown off
+# by shifted line numbers or changed surrounding context.
+diff_essence() {
+    { grep -E '^\+[^+]|^-[^-]' || true; } | sort
+}
+
+# Check if a file exists at a given git ref
+file_exists_at_ref() {
+    git -C "$REPO_ROOT" cat-file -t "$1:$2" >/dev/null 2>&1
+}
+
+# Compare the Red Hat delta for each file before and after the sync.
+# Only include files where the substantive delta changed.
+# Also detect merge artifacts: files that upstream deleted/renamed but
+# survived the merge.
+CHANGED_FILES=()
+STALE_FILES=()
+DIVERGED_FILES=()
+while IFS= read -r file; do
+    # Detect stale files: file exists on merge branch but was removed/renamed
+    # upstream (not in new tag) and was an upstream file (existed in old tag).
+    # These are not Red Hat changes — they should have been removed by the merge.
+    if ! file_exists_at_ref "tags/$TAG" "$file" && file_exists_at_ref "tags/$OLD_TAG" "$file"; then
+        STALE_FILES+=("$file")
+        continue
+    fi
+
+    old_delta=$(git -C "$REPO_ROOT" diff "tags/$OLD_TAG..$BASE" -- "$file" | diff_essence)
+    new_delta=$(git -C "$REPO_ROOT" diff "tags/$TAG..$BRANCH" -- "$file" | diff_essence)
+
+    if [[ "$old_delta" != "$new_delta" ]]; then
+        # If the file had no Red Hat delta before but now differs from upstream,
+        # and the file exists on the upstream tag, it's a merge artifact — the
+        # merge produced content that doesn't match upstream exactly.
+        if [[ -z "$old_delta" ]] && [[ -n "$new_delta" ]] && file_exists_at_ref "tags/$TAG" "$file"; then
+            DIVERGED_FILES+=("$file")
+            continue
+        fi
+        CHANGED_FILES+=("$file")
+    fi
+done <<< "$ALL_RH_FILES"
+
+# Warn about stale files (upstream deleted/renamed but still on merge branch)
+if [[ ${#STALE_FILES[@]} -gt 0 ]]; then
+    echo "" >&2
+    echo "WARNING: The following files were deleted or renamed upstream but still" >&2
+    echo "exist on the merge branch. These may need to be removed:" >&2
+    for f in "${STALE_FILES[@]}"; do
+        echo "  - $f" >&2
+    done
+    echo "" >&2
+fi
+
+# Warn about diverged files (merge produced content that differs from upstream)
+if [[ ${#DIVERGED_FILES[@]} -gt 0 ]]; then
+    echo "WARNING: The following files diverged from upstream during the merge." >&2
+    echo "These are not Red Hat changes but the merge produced content that" >&2
+    echo "doesn't match upstream. Consider resetting them to the upstream version:" >&2
+    for f in "${DIVERGED_FILES[@]}"; do
+        echo "  - $f" >&2
+    done
+    echo "  To fix: git checkout tags/$TAG -- <file>" >&2
+    echo "" >&2
+fi
+
+if [[ ${#CHANGED_FILES[@]} -eq 0 ]]; then
+    echo "No Red Hat-specific changes for this sync." >&2
+    exit 0
+fi
+
+# Generate the output: show the NEW Red Hat delta for changed files
+if [[ "$STAT_ONLY" == true ]]; then
+    git -C "$REPO_ROOT" diff --stat "tags/$TAG..$BRANCH" -- "${CHANGED_FILES[@]}"
+    exit 0
+fi
+
+DIFF_OUTPUT=$(git -C "$REPO_ROOT" diff "tags/$TAG..$BRANCH" -- "${CHANGED_FILES[@]}")
+
+if [[ -z "$DIFF_OUTPUT" ]]; then
+    echo "No Red Hat-specific changes for this sync." >&2
+    exit 0
+fi
+
+# Post to PR or print to stdout
+if [[ -n "$PR_NUMBER" ]]; then
+    STAT_OUTPUT=$(git -C "$REPO_ROOT" diff --stat "tags/$TAG..$BRANCH" -- "${CHANGED_FILES[@]}")
+
+    WARNINGS_SECTION=""
+    if [[ ${#STALE_FILES[@]} -gt 0 ]]; then
+        STALE_LIST=""
+        for f in "${STALE_FILES[@]}"; do
+            STALE_LIST+=$'\n'"- \`$f\`"
+        done
+        WARNINGS_SECTION+=$(cat <<STALE
+
+### :warning: Stale files (upstream deleted/renamed)
+
+The following files were deleted or renamed upstream between \`$OLD_TAG\` and \`$TAG\`
+but still exist on this branch. They may need to be removed:
+$STALE_LIST
+
+STALE
+        )
+    fi
+
+    if [[ ${#DIVERGED_FILES[@]} -gt 0 ]]; then
+        DIVERGED_LIST=""
+        for f in "${DIVERGED_FILES[@]}"; do
+            DIVERGED_LIST+=$'\n'"- \`$f\`"
+        done
+        WARNINGS_SECTION+=$(cat <<DIVERGED
+
+### :warning: Diverged files (merge artifacts)
+
+The following files have no intentional Red Hat modifications but diverged from
+upstream during the merge. Consider resetting them: \`git checkout tags/$TAG -- <file>\`
+$DIVERGED_LIST
+
+DIVERGED
+        )
+    fi
+
+    COMMENT_BODY=$(cat <<EOF
+## Red Hat-specific changes (vs upstream \`$TAG\`)
+
+These are the Red Hat-specific changes that were added or modified in this sync.
+Reviewers: focus your review on these changes -- everything else is from upstream
+or unchanged Red Hat modifications.
+
+Previously synced to: \`$OLD_TAG\`
+$WARNINGS_SECTION
+### Summary
+\`\`\`
+$STAT_OUTPUT
+\`\`\`
+
+<details>
+<summary>Full diff (click to expand)</summary>
+
+\`\`\`diff
+$DIFF_OUTPUT
+\`\`\`
+
+</details>
+EOF
+    )
+
+    echo "Posting Red Hat diff to PR #$PR_NUMBER..." >&2
+    gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY" --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+    echo "Done. Comment posted to PR #$PR_NUMBER." >&2
+else
+    echo "$DIFF_OUTPUT"
+fi

--- a/scripts/redhat-diff.sh
+++ b/scripts/redhat-diff.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+#
+# redhat-diff.sh - Show only Red Hat-specific changes introduced or modified during
+#                  an upstream sync, filtering out pure upstream changes and unchanged
+#                  Red Hat modifications.
+#
+# How it works:
+#   For each file that has Red Hat modifications on the merge branch, the script
+#   compares the "Red Hat delta" (diff from upstream tag) before and after the sync.
+#   Only files where this delta changed are shown — meaning the Red Hat-specific
+#   modifications were added, updated, or removed during this sync.
+#
+# Usage:
+#   ./scripts/redhat-diff.sh                    # print diff to stdout
+#   ./scripts/redhat-diff.sh --stat             # print diffstat summary only
+#   ./scripts/redhat-diff.sh --pr <number>      # post diff as a comment on a GitHub PR
+#   ./scripts/redhat-diff.sh --tag <tag>        # override the new tag from SYNC.md
+#   ./scripts/redhat-diff.sh --branch <branch>  # compare against a branch other than HEAD
+#   ./scripts/redhat-diff.sh --base <branch>    # base branch to compare from (default: main)
+#   ./scripts/redhat-diff.sh --all              # show cumulative Red Hat delta from upstream
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo "Error: not inside a git repository" >&2
+    exit 1
+}
+SYNC_FILE="$REPO_ROOT/SYNC.md"
+
+# Defaults
+TAG=""
+BRANCH="HEAD"
+BASE="main"
+PR_NUMBER=""
+STAT_ONLY=false
+SHOW_ALL=false
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Show Red Hat-specific changes made during an upstream sync.
+
+By default, compares the Red Hat delta (diff from upstream) before and after
+the sync. Only files where the Red Hat modifications changed are shown.
+Use --all to show the full cumulative Red Hat delta from upstream.
+
+Options:
+  --tag <tag>        Override the upstream tag (default: read from SYNC.md on branch)
+  --branch <branch>  Branch to compare (default: HEAD)
+  --base <branch>    Base branch to compare from (default: main)
+  --stat             Show diffstat summary only
+  --all              Show all Red Hat changes vs upstream (cumulative)
+  --pr <number>      Post the diff as a comment on the given GitHub PR
+  -h, --help         Show this help message
+EOF
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tag)    TAG="$2"; shift 2 ;;
+        --branch) BRANCH="$2"; shift 2 ;;
+        --base)   BASE="$2"; shift 2 ;;
+        --stat)   STAT_ONLY=true; shift ;;
+        --all)    SHOW_ALL=true; shift ;;
+        --pr)
+            if ! command -v gh >/dev/null 2>&1; then
+                echo "Error: the --pr flag requires the GitHub CLI (gh) to be installed." >&2
+                echo "Install it from https://cli.github.com/" >&2
+                exit 1
+            fi
+            PR_NUMBER="$2"; shift 2 ;;
+        -h|--help) usage ;;
+        *) echo "Unknown option: $1" >&2; usage ;;
+    esac
+done
+
+# Read new tag from SYNC.md on the branch being compared
+read_tag_from_ref() {
+    local ref="$1"
+    git -C "$REPO_ROOT" show "$ref:SYNC.md" 2>/dev/null \
+        | sed -n 's/^TAG:[[:space:]]*//p' \
+        | tr -d '[:space:]'
+}
+
+if [[ -z "$TAG" ]]; then
+    TAG=$(read_tag_from_ref "$BRANCH")
+    if [[ -z "$TAG" ]]; then
+        echo "Error: could not parse TAG from SYNC.md on $BRANCH" >&2
+        exit 1
+    fi
+fi
+
+# Verify the new tag exists locally
+if ! git -C "$REPO_ROOT" rev-parse "tags/$TAG" >/dev/null 2>&1; then
+    echo "Error: tag '$TAG' not found. Run 'git fetch authzed --tags' first." >&2
+    exit 1
+fi
+
+# --all mode: show cumulative Red Hat delta
+if [[ "$SHOW_ALL" == true ]]; then
+    echo "Comparing $BRANCH against upstream tag: $TAG (all Red Hat changes)" >&2
+    if [[ "$STAT_ONLY" == true ]]; then
+        git -C "$REPO_ROOT" diff --stat "tags/$TAG..$BRANCH"
+    else
+        git -C "$REPO_ROOT" diff "tags/$TAG..$BRANCH"
+    fi
+    exit 0
+fi
+
+# Read old tag from SYNC.md on the base branch
+OLD_TAG=$(read_tag_from_ref "$BASE")
+if [[ -z "$OLD_TAG" ]]; then
+    echo "Error: could not parse TAG from SYNC.md on $BASE" >&2
+    exit 1
+fi
+
+if ! git -C "$REPO_ROOT" rev-parse "tags/$OLD_TAG" >/dev/null 2>&1; then
+    echo "Error: old tag '$OLD_TAG' not found. Run 'git fetch authzed --tags' first." >&2
+    exit 1
+fi
+
+echo "Comparing Red Hat delta: $BASE ($OLD_TAG) -> $BRANCH ($TAG)" >&2
+
+# Get all files that have Red Hat modifications on either side
+ALL_RH_FILES=$(
+    {
+        git -C "$REPO_ROOT" diff --name-only "tags/$TAG..$BRANCH"
+        git -C "$REPO_ROOT" diff --name-only "tags/$OLD_TAG..$BASE"
+    } | sort -u
+)
+
+if [[ -z "$ALL_RH_FILES" ]]; then
+    echo "No Red Hat-specific changes found." >&2
+    exit 0
+fi
+
+# Extract only the added/removed lines from a diff, stripping headers,
+# hunk markers, and context lines so that comparisons are not thrown off
+# by shifted line numbers or changed surrounding context.
+diff_essence() {
+    { grep -E '^\+[^+]|^-[^-]' || true; } | sort
+}
+
+# Check if a file exists at a given git ref
+file_exists_at_ref() {
+    git -C "$REPO_ROOT" cat-file -t "$1:$2" >/dev/null 2>&1
+}
+
+# Compare the Red Hat delta for each file before and after the sync.
+# Only include files where the substantive delta changed.
+# Also detect merge artifacts: files that upstream deleted/renamed but
+# survived the merge.
+CHANGED_FILES=()
+STALE_FILES=()
+DIVERGED_FILES=()
+while IFS= read -r file; do
+    # Detect stale files: file exists on merge branch but was removed/renamed
+    # upstream (not in new tag) and was an upstream file (existed in old tag).
+    # These are not Red Hat changes — they should have been removed by the merge.
+    if ! file_exists_at_ref "tags/$TAG" "$file" && file_exists_at_ref "tags/$OLD_TAG" "$file"; then
+        STALE_FILES+=("$file")
+        continue
+    fi
+
+    old_delta=$(git -C "$REPO_ROOT" diff "tags/$OLD_TAG..$BASE" -- "$file" | diff_essence)
+    new_delta=$(git -C "$REPO_ROOT" diff "tags/$TAG..$BRANCH" -- "$file" | diff_essence)
+
+    if [[ "$old_delta" != "$new_delta" ]]; then
+        # If the file had no Red Hat delta before but now differs from upstream,
+        # and the file exists on the upstream tag, it's a merge artifact — the
+        # merge produced content that doesn't match upstream exactly.
+        if [[ -z "$old_delta" ]] && [[ -n "$new_delta" ]] && file_exists_at_ref "tags/$TAG" "$file"; then
+            DIVERGED_FILES+=("$file")
+            continue
+        fi
+        CHANGED_FILES+=("$file")
+    fi
+done <<< "$ALL_RH_FILES"
+
+# Warn about stale files (upstream deleted/renamed but still on merge branch)
+if [[ ${#STALE_FILES[@]} -gt 0 ]]; then
+    echo "" >&2
+    echo "WARNING: The following files were deleted or renamed upstream but still" >&2
+    echo "exist on the merge branch. These may need to be removed:" >&2
+    for f in "${STALE_FILES[@]}"; do
+        echo "  - $f" >&2
+    done
+    echo "" >&2
+fi
+
+# Warn about diverged files (merge produced content that differs from upstream)
+if [[ ${#DIVERGED_FILES[@]} -gt 0 ]]; then
+    echo "WARNING: The following files diverged from upstream during the merge." >&2
+    echo "These are not Red Hat changes but the merge produced content that" >&2
+    echo "doesn't match upstream. Consider resetting them to the upstream version:" >&2
+    for f in "${DIVERGED_FILES[@]}"; do
+        echo "  - $f" >&2
+    done
+    echo "  To fix: git checkout tags/$TAG -- <file>" >&2
+    echo "" >&2
+fi
+
+if [[ ${#CHANGED_FILES[@]} -eq 0 ]]; then
+    echo "No Red Hat-specific changes for this sync." >&2
+    exit 0
+fi
+
+# Generate the output: show the NEW Red Hat delta for changed files
+if [[ "$STAT_ONLY" == true ]]; then
+    git -C "$REPO_ROOT" diff --stat "tags/$TAG..$BRANCH" -- "${CHANGED_FILES[@]}"
+    exit 0
+fi
+
+DIFF_OUTPUT=$(git -C "$REPO_ROOT" diff "tags/$TAG..$BRANCH" -- "${CHANGED_FILES[@]}")
+
+if [[ -z "$DIFF_OUTPUT" ]]; then
+    echo "No Red Hat-specific changes for this sync." >&2
+    exit 0
+fi
+
+# Post to PR or print to stdout
+if [[ -n "$PR_NUMBER" ]]; then
+    STAT_OUTPUT=$(git -C "$REPO_ROOT" diff --stat "tags/$TAG..$BRANCH" -- "${CHANGED_FILES[@]}")
+
+    WARNINGS_SECTION=""
+    if [[ ${#STALE_FILES[@]} -gt 0 ]]; then
+        STALE_LIST=""
+        for f in "${STALE_FILES[@]}"; do
+            STALE_LIST+=$'\n'"- \`$f\`"
+        done
+        WARNINGS_SECTION+=$(cat <<STALE
+
+### :warning: Stale files (upstream deleted/renamed)
+
+The following files were deleted or renamed upstream between \`$OLD_TAG\` and \`$TAG\`
+but still exist on this branch. They may need to be removed:
+$STALE_LIST
+
+STALE
+        )
+    fi
+
+    if [[ ${#DIVERGED_FILES[@]} -gt 0 ]]; then
+        DIVERGED_LIST=""
+        for f in "${DIVERGED_FILES[@]}"; do
+            DIVERGED_LIST+=$'\n'"- \`$f\`"
+        done
+        WARNINGS_SECTION+=$(cat <<DIVERGED
+
+### :warning: Diverged files (merge artifacts)
+
+The following files have no intentional Red Hat modifications but diverged from
+upstream during the merge. Consider resetting them: \`git checkout tags/$TAG -- <file>\`
+$DIVERGED_LIST
+
+DIVERGED
+        )
+    fi
+
+    COMMENT_BODY=$(cat <<EOF
+## Red Hat-specific changes (vs upstream \`$TAG\`)
+
+These are the Red Hat-specific changes that were added or modified in this sync.
+Reviewers: focus your review on these changes -- everything else is from upstream
+or unchanged Red Hat modifications.
+
+Previously synced to: \`$OLD_TAG\`
+$WARNINGS_SECTION
+### Summary
+\`\`\`
+$STAT_OUTPUT
+\`\`\`
+
+<details>
+<summary>Full diff (click to expand)</summary>
+
+\`\`\`diff
+$DIFF_OUTPUT
+\`\`\`
+
+</details>
+EOF
+    )
+
+    echo "Posting Red Hat diff to PR #$PR_NUMBER..." >&2
+    gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY" --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+    echo "Done. Comment posted to PR #$PR_NUMBER." >&2
+else
+    echo "$DIFF_OUTPUT"
+fi

--- a/scripts/redhat-diff.sh
+++ b/scripts/redhat-diff.sh
@@ -94,7 +94,7 @@ fi
 
 # Verify the new tag exists locally
 if ! git -C "$REPO_ROOT" rev-parse "tags/$TAG" >/dev/null 2>&1; then
-    echo "Error: tag '$TAG' not found. Run 'git fetch authzed --tags' first." >&2
+    echo "Error: tag '$TAG' not found. Run 'git fetch upstream --tags' first." >&2
     exit 1
 fi
 
@@ -117,7 +117,7 @@ if [[ -z "$OLD_TAG" ]]; then
 fi
 
 if ! git -C "$REPO_ROOT" rev-parse "tags/$OLD_TAG" >/dev/null 2>&1; then
-    echo "Error: old tag '$OLD_TAG' not found. Run 'git fetch authzed --tags' first." >&2
+    echo "Error: old tag '$OLD_TAG' not found. Run 'git fetch upstream --tags' first." >&2
     exit 1
 fi
 

--- a/tools/validate-upgrade-path/main.go
+++ b/tools/validate-upgrade-path/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"strings"
 
@@ -115,7 +117,7 @@ USAGE:
   built-in update mechanism, to ensure you don't skip required migration steps.
 
 FLAGS:
-  -g, --graph FILE        Path to update-graph.yaml (default: config/update-graph.yaml)
+  -g, --graph SOURCE      Path or URL to update-graph.yaml (default: config/update-graph.yaml)
   -d, --datastore NAME    Datastore type: postgres, cockroachdb, mysql, spanner, memory
                           (default: postgres)
       --list-datastores   List available datastores and exit
@@ -132,6 +134,9 @@ EXAMPLES:
   # Use a different graph file (e.g. from an upstream bundle)
   validate-upgrade-path -g /path/to/update-graph.yaml v1.29.5 v1.35.3
 
+  # Use the graph directly from GitHub
+  validate-upgrade-path -g https://raw.githubusercontent.com/project-kessel/spicedb-operator/refs/heads/main/config/update-graph.yaml --list-versions
+
   # List available datastores
   validate-upgrade-path --list-datastores
 
@@ -140,10 +145,28 @@ EXAMPLES:
 `)
 }
 
-func loadGraph(path string) (*config.OperatorConfig, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
+func loadGraph(source string) (*config.OperatorConfig, error) {
+	var data []byte
+	var err error
+
+	if strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://") {
+		resp, err := http.Get(source)
+		if err != nil {
+			return nil, fmt.Errorf("fetching %s: %w", source, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("fetching %s: HTTP %d", source, resp.StatusCode)
+		}
+		data, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("reading response from %s: %w", source, err)
+		}
+	} else {
+		data, err = os.ReadFile(source)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var opConfig config.OperatorConfig
@@ -152,7 +175,7 @@ func loadGraph(path string) (*config.OperatorConfig, error) {
 	}
 
 	if len(opConfig.Channels) == 0 {
-		return nil, fmt.Errorf("no channels found in %s", path)
+		return nil, fmt.Errorf("no channels found in %s", source)
 	}
 
 	return &opConfig, nil

--- a/tools/validate-upgrade-path/main.go
+++ b/tools/validate-upgrade-path/main.go
@@ -1,0 +1,316 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/authzed/spicedb-operator/pkg/config"
+	"github.com/authzed/spicedb-operator/pkg/updates"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	args, err := parseArgs()
+	if err != nil {
+		return err
+	}
+
+	opConfig, err := loadGraph(args.graphFile)
+	if err != nil {
+		return fmt.Errorf("loading update graph from %s: %w", args.graphFile, err)
+	}
+
+	graph := &opConfig.UpdateGraph
+
+	// If listing datastores/versions, handle that and exit
+	if args.listDatastores {
+		return listDatastores(graph)
+	}
+	if args.listVersions {
+		return listVersions(graph, args.datastore)
+	}
+
+	// Validate upgrade path
+	if args.from == "" || args.to == "" {
+		return fmt.Errorf("both --from and --to are required (use --help for usage)")
+	}
+
+	return validateUpgrade(graph, args.datastore, args.from, args.to)
+}
+
+type cliArgs struct {
+	graphFile      string
+	datastore      string
+	from           string
+	to             string
+	listDatastores bool
+	listVersions   bool
+}
+
+func parseArgs() (cliArgs, error) {
+	args := cliArgs{
+		graphFile: "config/update-graph.yaml",
+		datastore: "postgres",
+	}
+
+	positional := make([]string, 0)
+	for i := 1; i < len(os.Args); i++ {
+		switch os.Args[i] {
+		case "--help", "-h":
+			printUsage()
+			os.Exit(0)
+		case "--graph", "-g":
+			i++
+			if i >= len(os.Args) {
+				return args, fmt.Errorf("--graph requires a value")
+			}
+			args.graphFile = os.Args[i]
+		case "--datastore", "-d":
+			i++
+			if i >= len(os.Args) {
+				return args, fmt.Errorf("--datastore requires a value")
+			}
+			args.datastore = os.Args[i]
+		case "--list-datastores":
+			args.listDatastores = true
+		case "--list-versions":
+			args.listVersions = true
+		default:
+			positional = append(positional, os.Args[i])
+		}
+	}
+
+	if !args.listDatastores && !args.listVersions {
+		if len(positional) == 2 {
+			args.from = positional[0]
+			args.to = positional[1]
+		} else if len(positional) != 0 {
+			return args, fmt.Errorf("expected exactly 2 positional args: FROM_VERSION TO_VERSION (got %d)", len(positional))
+		}
+	}
+
+	return args, nil
+}
+
+func printUsage() {
+	fmt.Fprintf(os.Stderr, `validate-upgrade-path - Validate SpiceDB upgrade paths against the update graph
+
+USAGE:
+  validate-upgrade-path [FLAGS] FROM_VERSION TO_VERSION
+
+  Checks whether upgrading from FROM_VERSION to TO_VERSION is supported by the
+  update graph for a given datastore. Shows the full step-by-step upgrade path
+  including any required migrations.
+
+  This is useful when managing your own SpiceDB images outside of the operator's
+  built-in update mechanism, to ensure you don't skip required migration steps.
+
+FLAGS:
+  -g, --graph FILE        Path to update-graph.yaml (default: config/update-graph.yaml)
+  -d, --datastore NAME    Datastore type: postgres, cockroachdb, mysql, spanner, memory
+                          (default: postgres)
+      --list-datastores   List available datastores and exit
+      --list-versions     List all versions for the given datastore and exit
+  -h, --help              Show this help
+
+EXAMPLES:
+  # Check if upgrading from v1.29.5 to v1.35.3 is valid for postgres
+  validate-upgrade-path v1.29.5 v1.35.3
+
+  # Check upgrade path for cockroachdb
+  validate-upgrade-path -d cockroachdb v1.29.5 v1.35.3
+
+  # Use a different graph file (e.g. from an upstream bundle)
+  validate-upgrade-path -g /path/to/update-graph.yaml v1.29.5 v1.35.3
+
+  # List available datastores
+  validate-upgrade-path --list-datastores
+
+  # List all versions for a datastore
+  validate-upgrade-path --list-versions -d postgres
+`)
+}
+
+func loadGraph(path string) (*config.OperatorConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var opConfig config.OperatorConfig
+	if err := yaml.Unmarshal(data, &opConfig); err != nil {
+		return nil, fmt.Errorf("parsing yaml: %w", err)
+	}
+
+	if len(opConfig.Channels) == 0 {
+		return nil, fmt.Errorf("no channels found in %s", path)
+	}
+
+	return &opConfig, nil
+}
+
+func listDatastores(graph *updates.UpdateGraph) error {
+	seen := make(map[string]bool)
+	for _, ch := range graph.Channels {
+		ds := ch.Metadata[updates.DatastoreMetadataKey]
+		if ds != "" && !seen[ds] {
+			fmt.Printf("  %s (channel: %s)\n", ds, ch.Name)
+			seen[ds] = true
+		}
+	}
+	return nil
+}
+
+func listVersions(graph *updates.UpdateGraph, datastore string) error {
+	for _, ch := range graph.Channels {
+		if !strings.EqualFold(ch.Metadata[updates.DatastoreMetadataKey], datastore) {
+			continue
+		}
+		fmt.Printf("Versions for %s (channel: %s):\n", datastore, ch.Name)
+		for _, node := range ch.Nodes {
+			migrationInfo := ""
+			if node.Migration != "" {
+				migrationInfo = fmt.Sprintf("  migration: %s", node.Migration)
+			}
+			phaseInfo := ""
+			if node.Phase != "" {
+				phaseInfo = fmt.Sprintf("  phase: %s", node.Phase)
+			}
+			fmt.Printf("  %s%s%s\n", node.ID, migrationInfo, phaseInfo)
+		}
+		return nil
+	}
+	return fmt.Errorf("no channel found for datastore %q", datastore)
+}
+
+func validateUpgrade(graph *updates.UpdateGraph, datastore, from, to string) error {
+	channelName, err := graph.DefaultChannelForDatastore(datastore)
+	if err != nil {
+		return fmt.Errorf("datastore %q not found in update graph", datastore)
+	}
+
+	source, err := graph.SourceForChannel(datastore, channelName)
+	if err != nil {
+		return err
+	}
+
+	// Check that both versions exist in the graph
+	fromState := source.State(from)
+	if fromState.ID == "" {
+		return fmt.Errorf("version %q not found in the %s channel for %s", from, channelName, datastore)
+	}
+	toState := source.State(to)
+	if toState.ID == "" {
+		return fmt.Errorf("version %q not found in the %s channel for %s", to, channelName, datastore)
+	}
+
+	// Try to find a path by walking edges from `from` toward `to`
+	// First create a subgraph with `to` as the head, then walk from `from`
+	subSource, err := source.Subgraph(to)
+	if err != nil {
+		fmt.Printf("UPGRADE NOT SUPPORTED: no path from %s to %s for %s\n", from, to, datastore)
+		fmt.Println("\nThe update graph does not define a valid upgrade path between these versions.")
+		return nil
+	}
+
+	// Walk the path from `from` to `to`
+	path := []pathStep{{
+		version:   from,
+		migration: fromState.Migration,
+		phase:     fromState.Phase,
+	}}
+
+	current := from
+	for current != to {
+		next := subSource.NextVersion(current)
+		if next == "" {
+			fmt.Printf("UPGRADE NOT SUPPORTED: no path from %s to %s for %s\n", from, to, datastore)
+			fmt.Println("\nThe update graph does not define a valid upgrade path between these versions.")
+			fmt.Println("You may need to upgrade through intermediate versions first.")
+			return nil
+		}
+		nextState := source.State(next)
+		step := pathStep{
+			version:   next,
+			migration: nextState.Migration,
+			phase:     nextState.Phase,
+		}
+
+		// Determine if this step requires a migration
+		prevState := source.State(current)
+		if nextState.Migration != prevState.Migration || nextState.Phase != prevState.Phase {
+			step.hasMigration = true
+		}
+
+		path = append(path, step)
+		current = next
+	}
+
+	// Print results
+	if len(path) <= 1 {
+		fmt.Printf("SAME VERSION: %s is already at %s\n", from, to)
+		return nil
+	}
+
+	migrationCount := 0
+	for _, s := range path[1:] {
+		if s.hasMigration {
+			migrationCount++
+		}
+	}
+
+	fmt.Printf("UPGRADE SUPPORTED: %s -> %s for %s\n", from, to, datastore)
+	fmt.Printf("  Steps: %d\n", len(path)-1)
+	fmt.Printf("  Migrations required: %d\n", migrationCount)
+	fmt.Println()
+
+	// Print the path
+	fmt.Println("Upgrade path:")
+	for i, step := range path {
+		prefix := "  "
+		if i == 0 {
+			prefix = "  [current] "
+		} else if i == len(path)-1 {
+			prefix = "  [target]  "
+		} else {
+			prefix = "  [step]    "
+		}
+
+		migNote := ""
+		if i > 0 && step.hasMigration {
+			migNote = fmt.Sprintf(" (migration: %s", step.migration)
+			if step.phase != "" {
+				migNote += fmt.Sprintf(", phase: %s", step.phase)
+			}
+			migNote += ")"
+		} else if i > 0 {
+			migNote = " (no migration)"
+		}
+
+		fmt.Printf("%s%s%s\n", prefix, step.version, migNote)
+	}
+
+	if migrationCount > 0 {
+		fmt.Println()
+		fmt.Println("NOTE: This upgrade requires database migrations. Ensure you follow each step")
+		fmt.Println("      in sequence and do not skip intermediate versions.")
+	}
+
+	return nil
+}
+
+type pathStep struct {
+	version      string
+	migration    string
+	phase        string
+	hasMigration bool
+}


### PR DESCRIPTION
* Added scripts/redhat-diff.sh to isolate Red Hat-specific changes from upstream sync PRs, making code review practical by filtering out upstream noise
* Added validate-upgrade-path CLI tool that validates SpiceDB upgrade paths against the operator's update graph, showing step-by-step upgrade sequences and required migrations.
* Added Makefile to build Red Hat-specific tooling (validate-upgrade-path)
* Restructured the drift tracking table in README-redhat.md to include file paths, per-file merge actions (Keep ours, Re-apply, Delete, Red Hat only), and individual rows for each workflow instead of bundled descriptions (for potential use by Claude)
* Added CLAUDE.md with merge conflict resolution rules to enable automated syncs via Claude Code
* Updated .gitignore to ignore the bin/ build output directory

UPDATE:
* added claude skill `sync-upstream` so that claude can be used using the `/sync-upstream` command
* added the skill and CLAUDE.md to README-redhat to ensure our specific claude configuration is tracked and properly managed during the sync process

## More on the validate-upgrade-path tool

The validate-upgrade-path tool reads the operator's config/update-graph.yaml to validate whether an upgrade between two SpiceDB versions is supported for a given datastore, including full step-by-step upgrade path any required migrations. It can also be used to list the versions available and supported by the operator.

```shell
  # Build the tool
  make build-validate-upgrade-path

  # Check if upgrading from v1.42.9 to v1.51.0 is valid for postgres
  bin/validate-upgrade-path v1.42.9 to v1.51.0

  # Check for cockroachdb
  bin/validate-upgrade-path -d cockroachdb v1.42.9 to v1.51.0

  # List available datastores or versions
  bin/validate-upgrade-path --list-datastores
  bin/validate-upgrade-path --list-versions -d postgres
```

Note: based on the version of spicedb operator we're running, were technically using a version of spicedb not listed in spicedb-operators graph which is exactly my concern. We were previously on v1.47.1 before upgrading to v1.49.2 so here is an example output of that upgrade

```shell
# this is on a branch using spicedb-operator v1.23.0 (newer than our release)
$ ./bin/validate-upgrade-path --list-versions | head -n 3
Versions for postgres (channel: stable):
  v1.49.2  migration: add-index-for-transaction-gc
  v1.48.0  migration: add-index-for-transaction-gc

$ ./bin/validate-upgrade-path v1.47.1 v1.49.2
UPGRADE SUPPORTED: v1.47.1 -> v1.49.2 for postgres
  Steps: 1
  Migrations required: 0

Upgrade path:
  [current] v1.47.1
  [target]  v1.49.2 (no migration)
```

## More on the redhat-diff.sh tool

The script compares the "Red Hat delta" (diff from upstream tag) before and after a sync. It reads the old tag from main's SYNC.md and the new tag from the merge branch's SYNC.md, then categorizes files into:  
* Red Hat changes: shown in diff output; files where Red Hat modifications were added or updated                         
* Stale files (warning): upstream deleted/renamed files that survived the merge and need removal
* Diverged files (warning): upstream files where the merge produced content that doesn't match the tag, with a fix command

```shell
  # Show diffstat summary of Red Hat changes              
  ./scripts/redhat-diff.sh --stat                         
                         
  # Full diff to stdout  
  ./scripts/redhat-diff.sh                                
                         
  # Compare a specific branch                             
  ./scripts/redhat-diff.sh --branch merge-upstream-v1.51.0                                 
                         
  # Post formatted comment on a PR (requires github CLI to work)                  
  ./scripts/redhat-diff.sh --pr <number>  
                         
  # Show cumulative Red Hat delta (all changes vs upstream)                                
  ./scripts/redhat-diff.sh --all        
```

The Red Hat changes shown in the diff can be provided on any upstream sync PR's to simplify the PR review process