### PR TITLE
minor bug fixes in skill process

### DIFF
--- a/.claude/skills/sync-upstream/SKILL.md
+++ b/.claude/skills/sync-upstream/SKILL.md
@@ -15,9 +15,63 @@ Syncs this fork from the latest upstream release of
 - `--tag <tag>` — (optional) override the upstream tag to sync to. If omitted,
   the skill auto-detects the latest release tag from upstream.
 
+## Required Remotes
+
+- `origin` — your personal fork (used for pushing branches)
+- `kessel` — `project-kessel/spicedb-operator` (the repo PRs target)
+- `upstream` — `authzed/spicedb-operator` (where upstream tags are fetched from)
+
 ## Process
 
-### Step 1: Determine the Target Tag
+### Step 1: Validate Prerequisites
+
+Before starting the sync, validate that all required tools and configuration are
+in place. Run all checks first, then report any issues together. For any issues
+found, offer to fix them (with user confirmation). Do not ask the user to perform
+manual steps unless they explicitly say they prefer to handle it themselves.
+
+1. **Validate git remotes** by running `git remote -v` and checking:
+   - `upstream` exists and points to `github.com/authzed/spicedb-operator` (HTTP or SSH)
+   - `kessel` exists and points to `github.com/project-kessel/spicedb-operator` (HTTP or SSH)
+   - `origin` exists (any URL is acceptable)
+
+   If a remote is missing, offer to add it:
+   ```bash
+   git remote add upstream https://github.com/authzed/spicedb-operator.git
+   git remote add kessel https://github.com/project-kessel/spicedb-operator.git
+   ```
+   If a remote exists but points to the wrong URL, offer to fix it:
+   ```bash
+   git remote set-url <name> <correct-url>
+   ```
+
+2. **Validate `gh` CLI is installed:**
+   ```bash
+   command -v gh
+   ```
+   If not installed, inform the user that `gh` is required for creating PRs and
+   posting review diffs. Link to https://cli.github.com/ and ask how they want
+   to proceed.
+
+3. **Validate `gh` CLI is authenticated:**
+   ```bash
+   gh auth status
+   ```
+   If not authenticated, offer to run `gh auth login` for the user.
+
+4. **Validate `gh` default repo is configured:**
+   ```bash
+   gh repo set-default --view
+   ```
+   The default repo should be `project-kessel/spicedb-operator`. If it is not
+   set or points to a different repo, offer to fix it:
+   ```bash
+   gh repo set-default project-kessel/spicedb-operator
+   ```
+
+Only proceed to Step 2 once all prerequisites pass.
+
+### Step 2: Determine the Target Tag
 
 If `--tag` was provided, use that. Otherwise, find the latest release tag from
 the upstream repository:
@@ -38,14 +92,16 @@ git show tags/<tag>:go.mod | grep -E '^go '
 If the Go version exceeds our go-toolset version, stop and report the issue.
 The current go-toolset version constraint is documented in `README-redhat.md`.
 
-### Step 2: Sync
+### Step 3: Sync
 
-1. `git checkout -b sync-upstream-<tag> tags/<tag>`
-2. `git checkout -b merge-upstream-<tag> main`
-3. `git merge sync-upstream-<tag>`
-4. Resolve any merge conflicts using the **Merge Action** column in the drift
+1. `git fetch upstream --tags` (if not already done)
+2. `git fetch kessel`
+3. `git checkout -b sync-upstream-<tag> tags/<tag>`
+4. `git checkout -b merge-upstream-<tag> kessel/main`
+5. `git merge sync-upstream-<tag>`
+6. Resolve any merge conflicts using the **Merge Action** column in the drift
    tracking table in `README-redhat.md`
-5. For `go.mod` and `go.sum` conflicts, reset to upstream entirely:
+7. For `go.mod` and `go.sum` conflicts, reset to upstream entirely:
    ```bash
    # Find all conflicting go.mod/go.sum/go.work files
    git diff --name-only --diff-filter=U --relative | grep -E "mod|sum|work"
@@ -53,9 +109,9 @@ The current go-toolset version constraint is documented in `README-redhat.md`.
    # Reset them to the upstream version
    git checkout sync-upstream-<tag> -- <file1> <file2> ...
    ```
-6. For any file not listed in the table, accept the upstream (incoming) version
+8. For any file not listed in the table, accept the upstream (incoming) version
 
-### Step 3: Update SYNC.md
+### Step 4: Update SYNC.md
 
 Update `SYNC.md` with the new tag and the commit SHA of the upstream tag:
 ```bash
@@ -63,7 +119,7 @@ git rev-parse tags/<tag>
 ```
 Commit the update.
 
-### Step 4: Post-Merge Cleanup
+### Step 5: Post-Merge Cleanup
 
 1. Run `./scripts/redhat-diff.sh --stat`
 2. Remove any **stale files** listed in the warning:
@@ -77,7 +133,7 @@ Commit the update.
 4. Commit the cleanup
 5. Re-run `./scripts/redhat-diff.sh --stat` to confirm clean output
 
-### Step 5: Build and Install validate-upgrade-path
+### Step 6: Build and Install validate-upgrade-path
 
 Build and install the tool so it is available system-wide:
 ```bash
@@ -88,19 +144,22 @@ Verify it is in PATH:
 which validate-upgrade-path
 ```
 
-### Step 6: Push and Create PR
+### Step 7: Push and Create PR
 
-1. Push the branch:
+1. Push the branch to your fork:
    ```bash
    git push origin merge-upstream-<tag>
    ```
-2. Create a PR to main (**do not squash commits**)
+2. Create a PR against the kessel repo (**do not squash commits when merging**):
+   ```bash
+   gh pr create --repo project-kessel/spicedb-operator --base main --title "..." --body "..."
+   ```
 3. Post the Red Hat diff on the PR:
    ```bash
    ./scripts/redhat-diff.sh --pr <pr-number>
    ```
 
-### Step 7: Summary
+### Step 8: Summary
 
 Report:
 - Old tag → new tag
@@ -108,3 +167,9 @@ Report:
 - Number of Red Hat changes, stale files cleaned, diverged files reset
 - Whether validate-upgrade-path was successfully installed
 - Remind the user to review the PR and check CI before merging
+
+**Important: Before merging this PR, you must also:**
+1. Update the `deploy/deploy.yml` file to align with the new upstream bundle.
+   See [Updating the SpiceDB Operator Deployment File](https://project-kessel.github.io/docs-internal-overlay/for-red-hatters/running-kessel/spicedb/syncing-spicedb-repos/#updating-the-spicedb-operator-deployment-file).
+2. Follow all post-sync steps at
+   https://project-kessel.github.io/docs-internal-overlay/for-red-hatters/running-kessel/spicedb/syncing-spicedb-repos/#after-syncing


### PR DESCRIPTION
Updates to the sync-upstream skill to correct recent issues:
* clearly defines 3 remotes and adds steps to check they exist and prompt for remediation if missing
* validates gh CLI is installed and configured and prompts if not to make sure steps are fully automated
* fixes the fetch/PR process using the correct remotes to avoid accidental upstream PRs with Authzed
* Does not prompt the user to run any steps manually unless they request to do so
* Adds warning at end of sync to make sure to update the bundle and follow after sync steps