### PR TITLE
RHCLOUD-48924: migrates to hummingbird base images

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,10 +1,7 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778072020 AS builder
-ARG TARGETARCH
-USER root
-RUN microdnf install -y tar gzip make which go-toolset
+# Build stage -- the Go toolchain embeds the validated FIPS module in all binaries automatically.
+FROM registry.access.redhat.com/hi/go:1.26.5-fips AS builder
 
 WORKDIR /go/src/app
-ENV CGO_ENABLED=1
 
 COPY go.mod go.sum ./
 RUN go mod download
@@ -13,11 +10,15 @@ COPY . .
 
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg/mod \
     go mod tidy && \
-    GOEXPERIMENT=strictfipsruntime,boringcrypto GOOS=linux GOARCH=${TARGETARCH} go build -tags=fips_enabled -o /usr/local/bin/spicedb-operator ./cmd/...
+    go build -o /usr/local/bin/spicedb-operator ./cmd/...
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778072020
+# Runtime stage -- set GODEBUG so the binary runs in FIPS mode.
+FROM registry.access.redhat.com/hi/core-runtime:2.42-openssl-fips
+
+WORKDIR /
 
 COPY --from=builder /usr/local/bin/spicedb-operator /usr/local/bin/spicedb-operator
 COPY --from=builder /go/src/app/config/update-graph.yaml /opt/operator/update-graph.yaml
 
+ENV GODEBUG=fips140=on
 ENTRYPOINT ["spicedb-operator"]

--- a/README-redhat.md
+++ b/README-redhat.md
@@ -25,7 +25,7 @@ The table below captures all changes to our fork from upstream. Each entry inclu
 | `.github/workflows/release.yaml` | Removed | Not applicable to our fork | Delete |
 | `.github/workflows/security-scanning.yml` | Added | Required ConsoleDot platform security workflow for CVE scanning | Red Hat only |
 | `.tekton/spicedb-operator-pull-request.yaml`, `.tekton/spicedb-operator-push.yaml` | Added | Konflux PR and merge build pipelines | Red Hat only |
-| `Dockerfile.openshift` | Added | FIPS-compliant builds using UBI base image and Go Toolset for Konflux | Red Hat only |
+| `Dockerfile.openshift` | Added | FIPS-compliant builds using Hummingbird base images for Konflux | Red Hat only |
 | `build_deploy.sh` | Added | Legacy App Interface build script, still used for local image builds when testing operator updates | Red Hat only |
 | `deploy/deploy.yml` | Added | Main deployment file for SpiceDB Operator on OpenShift clusters with CRDs, RBAC, and customizations for OpenShift (see deployment table below) | Red Hat only |
 | `config/operator_openshift.yaml` | Added | OpenShift-specific operator configuration | Red Hat only |
@@ -44,24 +44,17 @@ The table below captures all changes to our fork from upstream. Each entry inclu
 
 ### More on our Dockerfile and Builds
 
-**UBI Base Images**
+**Hummingbird Base Images**
 
-To comply with [Red Hat Software Certification policies](https://docs.redhat.com/en/documentation/red_hat_software_certification/2025/html-single/red_hat_openshift_software_certification_policy_guide/index#con-image-content-requirements_openshift-sw-cert-policy-container-images), UBI images are used as the base image for both building and running the container image. This ensures images are built to Red Hat security standards, comply with our build processes, and ensures that application runtime dependencies, such as operating system components and libraries, are covered under the customer’s subscription (where applicable). Our current UBI base image specifically targets RHEL 9.x to ensure it contains [FIPS-validated cryptographic modules](https://access.redhat.com/compliance/fips) for running in FedRAMP environments.
+Our Dockerfiles use Red Hat Hummingbird images for both building and running the container. The builder stage uses `registry.access.redhat.com/hi/go:x.y.z-fips`, which provides a Go toolchain that automatically embeds a validated FIPS module into all compiled binaries. The runtime stage uses `registry.access.redhat.com/hi/core-runtime:x.y.z-openssl-fips`, a minimal image with OpenSSL FIPS support. At runtime, `GODEBUG=fips140=on` is set to activate FIPS mode.
 
-
-**Go Toolset**
-
-To ensure FIPS compliant binaries for running in FedRAMP environments, we leverage Go Toolset vs upstream Go for all builds. While upstream Go is currently [working on FIPS 140-3 certification](https://go.dev/blog/fips140), these modules are still in process and under review and therefore are not validated nor shipped with any RHEL products including UBI based images.
-
-Go Toolset leverages a fork of Go which is based on the upstream work to enable Go to link against the C library Boring Crypto. This fork uses OpenSSL instead of BoringSSL which is already FIPS validated on RHEL systems (hence the reliance on specific versions of UBI such as 9.x). When upstream Go has finished FIPS validation, it is expected that Go Toolset will converge to using upstream Go and will remain our install target long term on UBI images.
+This replaces the previous approach of UBI 9 base images with Go Toolset, `CGO_ENABLED=1`, `GOEXPERIMENT=strictfipsruntime,boringcrypto`, and the `fips_enabled` build tag. With Hummingbird, FIPS compliance is handled transparently by the Go toolchain and runtime image, eliminating the need for manual FIPS build flags.
 
 **Go and Base Image Updates**
 
-With our reliance on Go Toolset and FIPS-validated OpenSSL modules, our ability to sync upstream code changes can be limited due to Go versions used upstream. The version of Go listed in our `go.mod` file must not be greater than the [latest version](https://catalog.redhat.com/en/software/containers/ubi9/go-toolset/61e5c00b4ec9945c18787690) of Go Toolset available for the specific UBI version in use. This is required to remain FIPS compliant and have FIPS-validated OpenSSL modules. Base images must also be updated with care to ensure only validated versions of RHEL are used.
+The Go version in `go.mod` should be compatible with the version of Go available in the Hummingbird builder image (`hi/go`). Base images should be updated as new validated versions become available.
 
-For more info on Go Toolset and FIPS certifications at Red Hat:
-* [Golang-FIPS](https://github.com/golang-fips/go/blob/main/README.md)
-* [FIPS Mode for Red Hat Go Toolset](https://developers.redhat.com/articles/2025/01/23/fips-mode-red-hat-go-toolset)
+For more info on FIPS compliance at Red Hat:
 * [Red Hat FIPS Compliance](https://access.redhat.com/compliance/fips)
 
 **Deployment File**


### PR DESCRIPTION
* Migrates base images to use hummingbird base images
* Updates README-redhat.md for the changes

Local validation that the operator image runs and can create SpiceDB Clusters (tested with Kind following the upstream guide: https://github.com/authzed/spicedb-operator#getting-started)

```shell
$ kc get pods
NAME                               READY   STATUS    RESTARTS   AGE
dev-spicedb-57656d9795-s58nv       1/1     Running   0          63s
spicedb-operator-69775f8c9-s4xl7   1/1     Running   0          5m18s

$ kc get spicedbclusters
NAME   AGE   CHANNEL   DESIRED   CURRENT   WARNINGS   MIGRATING   UPDATING   INVALID   PAUSED
dev    66s                       v1.52.0   True                                        

# note, the warning is because of lack of TLS configured

$ kc get pod -o yaml spicedb-operator-69775f8c9-s4xl7 | grep image:
    image: quay.io/anatale/spicedb-operator-hummingbird:v1
    image: quay.io/anatale/spicedb-operator-hummingbird:v1
```
